### PR TITLE
스프링 컨테이너와 빈 예제 추가

### DIFF
--- a/src/main/java/project/core/AppConfig.java
+++ b/src/main/java/project/core/AppConfig.java
@@ -17,16 +17,19 @@ public class AppConfig {
 
     @Bean
     public UserService userService() {
+        System.out.println("Call AppConfig.userService");
         return new UserServiceImpl(userRepository());
     }
 
     @Bean
     public UserRepository userRepository() {
+        System.out.println("Call AppConfig.userRepository");
         return new MemoryUserRepository();
     }
 
     @Bean
     public OrderService orderService() {
+        System.out.println("Call AppConfig.orderService");
         return new OrderServiceImpl(userRepository(), discountPolicy());
     }
 

--- a/src/main/java/project/core/order/OrderServiceImpl.java
+++ b/src/main/java/project/core/order/OrderServiceImpl.java
@@ -21,4 +21,9 @@ public class OrderServiceImpl implements OrderService {
 
         return new Order(userId, itemName, itemPrice, discountPrice);
     }
+
+    // 테스트 용도
+    public UserRepository getUserRepository() {
+        return userRepository;
+    }
 }

--- a/src/main/java/project/core/user/UserServiceImpl.java
+++ b/src/main/java/project/core/user/UserServiceImpl.java
@@ -17,4 +17,9 @@ public class UserServiceImpl implements UserService {
     public User findUser(Long userId) {
         return userRepository.findById(userId);
     }
+
+    // 테스트 용도
+    public UserRepository getUserRepository() {
+        return userRepository;
+    }
 }

--- a/src/test/java/project/core/beandefinition/BeanDefinitionTest.java
+++ b/src/test/java/project/core/beandefinition/BeanDefinitionTest.java
@@ -1,0 +1,27 @@
+package project.core.beandefinition;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import project.core.AppConfig;
+
+public class BeanDefinitionTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+    @DisplayName("빈 메타설정 정보 조회")
+    @Test
+    void findApplicationBean() {
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+
+        for (String beanDefinitionName : beanDefinitionNames) {
+            BeanDefinition beanDefinition = ac.getBeanDefinition(beanDefinitionName);
+
+            if (beanDefinition.getRole() == BeanDefinition.ROLE_APPLICATION) {
+                System.out.println("beanDefinitionName = " + beanDefinitionName
+                        + " beanDefinition = " + beanDefinition);
+            }
+        }
+    }
+}

--- a/src/test/java/project/core/beanfind/ApplicationContextBasicFindTest.java
+++ b/src/test/java/project/core/beanfind/ApplicationContextBasicFindTest.java
@@ -1,0 +1,45 @@
+package project.core.beanfind;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import project.core.AppConfig;
+import project.core.user.UserService;
+import project.core.user.UserServiceImpl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ApplicationContextBasicFindTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+    @DisplayName("빈 이름으로 조회")
+    @Test
+    void findBeanByName() {
+        UserService userService = ac.getBean("userService", UserService.class);
+        assertThat(userService).isInstanceOf(UserServiceImpl.class);
+    }
+
+    @DisplayName("이름 없이 타임으로만 조회")
+    @Test
+    void findBeanByType() {
+        UserService userService = ac.getBean(UserService.class);
+        assertThat(userService).isInstanceOf(UserServiceImpl.class);
+    }
+
+    @DisplayName("구체 타입으로 조회")
+    @Test
+    void findBeanByName2() {
+        UserService userService = ac.getBean("userService", UserServiceImpl.class);
+        assertThat(userService).isInstanceOf(UserServiceImpl.class);
+    }
+
+    @DisplayName("빈 이름으로 조회 X")
+    @Test
+    void findBeanByNameX() {
+        assertThrows(NoSuchBeanDefinitionException.class,
+                () -> ac.getBean("xxxxx", UserService.class));
+    }
+}

--- a/src/test/java/project/core/beanfind/ApplicationContextExtendsFindTest.java
+++ b/src/test/java/project/core/beanfind/ApplicationContextExtendsFindTest.java
@@ -1,0 +1,78 @@
+package project.core.beanfind;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import project.core.discount.DiscountPolicy;
+import project.core.discount.FixDiscountPolicy;
+import project.core.discount.RateDiscountPolicy;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ApplicationContextExtendsFindTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(TestConfig.class);
+
+    @DisplayName("부모 타입으로 조회 시, 자식이 둘 이상이면 중복 오류가 발생")
+    @Test
+    void findBeanByParentTypeDuplicate() {
+        assertThrows(NoUniqueBeanDefinitionException.class,
+                () -> ac.getBean(DiscountPolicy.class));
+    }
+
+    @DisplayName("부모 타입으로 조회 시, 자식이 둘 이상이면 빈 이름을 지정")
+    @Test
+    void findBeanByParentTypeBeanName() {
+        DiscountPolicy rateDiscountPolicy = ac.getBean("rateDiscountPolicy", DiscountPolicy.class);
+        assertThat(rateDiscountPolicy).isInstanceOf(RateDiscountPolicy.class);
+    }
+
+    @DisplayName("특정 하위 타입으로 조회")
+    @Test
+    void findBeanBySubType() {
+        RateDiscountPolicy bean = ac.getBean("rateDiscountPolicy", RateDiscountPolicy.class);
+        assertThat(bean).isInstanceOf(RateDiscountPolicy.class);
+    }
+
+    @DisplayName("부모 타입으로 모두 조회")
+    @Test
+    void findAllBeanByParentType() {
+        Map<String, DiscountPolicy> beansOfType = ac.getBeansOfType(DiscountPolicy.class);
+        assertThat(beansOfType.size()).isEqualTo(2);
+
+        for (String key : beansOfType.keySet()) {
+            System.out.println("key = " + key + " value = " + beansOfType.get(key));
+        }
+    }
+
+    @DisplayName("부모 타입으로 모두 조회")
+    @Test
+    void findAllBeanByObjectType() {
+        Map<String, Object> beansOfType = ac.getBeansOfType(Object.class);
+
+        for (String key : beansOfType.keySet()) {
+            System.out.println("key = " + key + " value = " + beansOfType.get(key));
+        }
+    }
+
+    @Configuration
+    static class TestConfig {
+
+        @Bean
+        public DiscountPolicy rateDiscountPolicy() {
+            return new RateDiscountPolicy();
+        }
+
+        @Bean
+        public DiscountPolicy fixDiscountPolicy() {
+            return new FixDiscountPolicy();
+        }
+
+    }
+}

--- a/src/test/java/project/core/beanfind/ApplicationContextInfoTest.java
+++ b/src/test/java/project/core/beanfind/ApplicationContextInfoTest.java
@@ -1,0 +1,40 @@
+package project.core.beanfind;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import project.core.AppConfig;
+
+public class ApplicationContextInfoTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+    @DisplayName("모든 빈 출력하기")
+    @Test
+    void findAllBean() {
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+
+        for (String beanDefinitionName : beanDefinitionNames) {
+            Object bean = ac.getBean(beanDefinitionName);
+            System.out.println("bean = " + bean + " object = " + bean);
+        }
+    }
+
+    @DisplayName("애플리케이션 빈 출력하기")
+    @Test
+    void findApplicationBean() {
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+
+        for (String beanDefinitionName : beanDefinitionNames) {
+            BeanDefinition beanDefinition = ac.getBeanDefinition(beanDefinitionName);
+
+            //Role ROLE_APPLICATION: 직접 등록한 애플리케이션 빈
+            //Role ROLE_INFRASTRUCTURE: 스프링이 내부에서 사용하는 빈
+            if (beanDefinition.getRole() == BeanDefinition.ROLE_APPLICATION) {
+                Object bean = ac.getBean(beanDefinitionName);
+                System.out.println("bean = " + bean + " object = " + bean);
+            }
+        }
+    }
+}

--- a/src/test/java/project/core/beanfind/ApplicationContextSameBeanFindTest.java
+++ b/src/test/java/project/core/beanfind/ApplicationContextSameBeanFindTest.java
@@ -1,0 +1,59 @@
+package project.core.beanfind;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import project.core.user.MemoryUserRepository;
+import project.core.user.UserRepository;
+
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ApplicationContextSameBeanFindTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(SameBeanConfig.class);
+
+    @DisplayName("타입으로 조회 시 같은 타입이 둘 이상 있으면, 중복 오류 발생")
+    @Test
+    void findBeanByTypeDuplicate() {
+        assertThrows(NoUniqueBeanDefinitionException.class, () -> ac.getBean(UserRepository.class));
+    }
+
+    @DisplayName("타입으로 조회 시 같은 타입이 둘 이상 있으면, 빈 이름 지정 필수")
+    @Test
+    void findBeanByName() {
+        UserRepository bean = ac.getBean("userRepository1", UserRepository.class);
+        assertThat(bean).isInstanceOf(UserRepository.class);
+    }
+
+    @DisplayName("특정 타입을 모두 조회")
+    @Test
+    void findAllBeanByType() {
+        Map<String, UserRepository> beansOfType = ac.getBeansOfType(UserRepository.class);
+
+        for (String key : beansOfType.keySet()) {
+            System.out.println("key = " + key + " value = " + beansOfType.get(key));
+        }
+        System.out.println("beansOfType = " + beansOfType);
+        assertThat(beansOfType.size()).isEqualTo(2);
+    }
+
+    @Configuration
+    static class SameBeanConfig {
+
+        @Bean
+        public UserRepository userRepository1() {
+            return new MemoryUserRepository();
+        }
+
+        @Bean
+        public UserRepository userRepository2() {
+            return new MemoryUserRepository();
+        }
+    }
+}

--- a/src/test/java/project/core/singleton/ConfigurationSingletonTest.java
+++ b/src/test/java/project/core/singleton/ConfigurationSingletonTest.java
@@ -1,0 +1,41 @@
+package project.core.singleton;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import project.core.AppConfig;
+import project.core.order.OrderServiceImpl;
+import project.core.user.UserRepository;
+import project.core.user.UserServiceImpl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigurationSingletonTest {
+
+    @Test
+    void configurationTest() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+        UserServiceImpl userService = ac.getBean(UserServiceImpl.class);
+        OrderServiceImpl orderService = ac.getBean(OrderServiceImpl.class);
+        UserRepository userRepository = ac.getBean(UserRepository.class);
+
+        UserRepository userRepository1 = userService.getUserRepository();
+        UserRepository userRepository2 = orderService.getUserRepository();
+
+        System.out.println("userService -> userRepository = " + userRepository1);
+        System.out.println("orderService -> userRepository = " + userRepository2);
+        System.out.println("userRepository = " + userRepository);
+
+        assertThat(userRepository1).isSameAs(userRepository);
+        assertThat(userRepository2).isSameAs(userRepository);
+    }
+
+    @Test
+    void configurationDeep() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+        AppConfig bean = ac.getBean(AppConfig.class);
+
+        System.out.println("bean = " + bean.getClass());
+    }
+}

--- a/src/test/java/project/core/singleton/SingletonService.java
+++ b/src/test/java/project/core/singleton/SingletonService.java
@@ -1,0 +1,17 @@
+package project.core.singleton;
+
+public class SingletonService {
+
+    private static final SingletonService instance = new SingletonService();
+
+    public static SingletonService getInstance() {
+        return instance;
+    }
+
+    private SingletonService() {
+    }
+
+    public void logic() {
+        System.out.println("싱글톤 객체 로직 호출");
+    }
+}

--- a/src/test/java/project/core/singleton/SingletonTest.java
+++ b/src/test/java/project/core/singleton/SingletonTest.java
@@ -1,0 +1,51 @@
+package project.core.singleton;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import project.core.AppConfig;
+import project.core.user.UserService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SingletonTest {
+
+    @DisplayName("스프링 없는 순수한 DI 컨테이너")
+    @Test
+    void pureContainer() {
+        AppConfig appConfig = new AppConfig();
+        UserService userService1 = appConfig.userService();
+        UserService userService2 = appConfig.userService();
+
+        System.out.println("userService1 = " + userService1);
+        System.out.println("userService2 = " + userService2);
+
+        assertThat(userService1).isNotSameAs(userService2);
+    }
+
+    @DisplayName("싱글톤 패턴을 적용한 객체 사용")
+    @Test
+    void singletonServiceTest() {
+        SingletonService singletonService1 = SingletonService.getInstance();
+        SingletonService singletonService2 = SingletonService.getInstance();
+
+        System.out.println("singletonService1 = " + singletonService1);
+        System.out.println("singletonService2 = " + singletonService2);
+
+        assertThat(singletonService1).isSameAs(singletonService2);
+    }
+
+    @DisplayName("스프링 컨테이너와 싱글톤")
+    @Test
+    void springContainer() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+        UserService userService1 = ac.getBean("userService", UserService.class);
+        UserService userService2 = ac.getBean("userService", UserService.class);
+
+        System.out.println("userService1 = " + userService1);
+        System.out.println("userService2 = " + userService2);
+
+        assertThat(userService1).isSameAs(userService2);
+    }
+}

--- a/src/test/java/project/core/singleton/StatefulService.java
+++ b/src/test/java/project/core/singleton/StatefulService.java
@@ -1,0 +1,16 @@
+package project.core.singleton;
+
+public class StatefulService {
+
+//    private int price;
+
+    public int order(String name, int price) {
+        System.out.println("name = " + name + " price = " + price);
+//        this.price = price;
+        return price;
+    }
+
+//    public int getPrice() {
+//        return price;
+//    }
+}

--- a/src/test/java/project/core/singleton/StatefulServiceTest.java
+++ b/src/test/java/project/core/singleton/StatefulServiceTest.java
@@ -1,0 +1,36 @@
+package project.core.singleton;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StatefulServiceTest {
+
+    @Test
+    void statefulServiceSingleton() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(TestConfig.class);
+        StatefulService statefulService1 = ac.getBean(StatefulService.class);
+        StatefulService statefulService2 = ac.getBean(StatefulService.class);
+
+        int userAPrice = statefulService1.order("userA", 10_000);
+        int userBPrice = statefulService2.order("userB", 20_000);
+
+//        int price = statefulService1.getPrice();
+//        System.out.println("price = " + price);
+
+        assertThat(userAPrice).isEqualTo(10_000);
+    }
+
+    @Configuration
+    static class TestConfig {
+
+        @Bean
+        public StatefulService statefulService() {
+            return new StatefulService();
+        }
+    }
+}


### PR DESCRIPTION
## 📚 연관된 이슈
close #5 

## 💻 구현 내용
- 스프링 빈 예제 추가
  - 기본적인 스프링 빈 조회
  - 동일한 타입이 둘 이상인 경우
  - 상속 관계
- 스프링 컨테이너 예제 추가
  - BeanDefinition
  - 싱글톤 컨테이너
  - `@Configuration`, `@Bean`, `CGLIB`
